### PR TITLE
SAAPG6223-92 Tornar tela de badges responsiva

### DIFF
--- a/src/app/components/Dashboard/usuario-dashboard/usuario-badges/listagem-usuario-badges/listagem-usuario-badges.component.css
+++ b/src/app/components/Dashboard/usuario-dashboard/usuario-badges/listagem-usuario-badges/listagem-usuario-badges.component.css
@@ -1,3 +1,9 @@
+.card-container {
+    display: flex;    /* display flex adicionado para deixar os cards alinhados */
+    flex-wrap: wrap; /* flex wrap adicionado para quebra de linha dos cards
+                        ao diminuir a tela */
+}
+
 /* CARD JAVA */
 .title-java {
     margin-left: 80px;
@@ -6,14 +12,14 @@
 .img-java {
     max-width: 120px;
     left: 25%;
+    margin-left: 8px;
 }
 
 .card-java {
-    position: absolute;
     left: 20%;
     top: 15%;
     max-width: 250px;
-
+    margin: 10px;
 }
 
 /* CARD PYTON */
@@ -27,7 +33,6 @@
 }
 
 .card-pyton {
-    position: absolute;
     left: 45%;
     top: 15%;
     max-width: 250px;
@@ -44,7 +49,6 @@
 }
 
 .card-html {
-    position: absolute;
     left: 70%;
     top: 15%;
     max-width: 250px;
@@ -61,7 +65,6 @@
 }
 
 .card-css {
-    position: absolute;
     left: 20%;
     top: 70%;
     max-width: 250px;

--- a/src/app/components/Dashboard/usuario-dashboard/usuario-badges/listagem-usuario-badges/listagem-usuario-badges.component.html
+++ b/src/app/components/Dashboard/usuario-dashboard/usuario-badges/listagem-usuario-badges/listagem-usuario-badges.component.html
@@ -1,3 +1,4 @@
+<div class="card-container">
     <mat-card class="card-java" *ngFor="let badge of badges">
         <mat-card-header>
             <mat-card-title class="title-java">
@@ -15,3 +16,4 @@
             <button mat-button>MAIS DETALHES</button>
         </mat-card-actions>
     </mat-card>
+</div>


### PR DESCRIPTION
**Havia um erro que fazia com que os badges ficassem um em cima do outro na tela:**

![Screenshot 2023-11-04 212632](https://github.com/adssenacgit/aprendizagemFrontendAngular/assets/92600558/60dcdc2c-e6d8-4308-b32f-e3c67a38685f)

O bug foi corrigido ao retirar as tags "position: absolute" do css, que faziam os cards assumirem uma posicao fixa absoluta.
Uma div foi criada pra abrigar os cards, e logo apos, foi adicionado um "display: flex" para que os cards ficassem alinhados horizontalmente, junto com um margin pra dar espaco entre eles:

![image_2023-11-05_225427066](https://github.com/adssenacgit/aprendizagemFrontendAngular/assets/92600558/cc4b117d-5ca0-4aed-961a-dd73095ba565)

Depois foi adicionado um "flex-wrap: wrap" na div, que faz com que os cards quebrem linha ao faltar espaco na tela, criando assim uma responsividade:


https://github.com/adssenacgit/aprendizagemFrontendAngular/assets/92600558/bdc50072-de69-49e4-be5d-d702620fc960


OBS:
Todos esses nomes diferentes de card no css ja estavam antes, achei estranho mas resolvi nao mexer nisso por nao saber se eh algo importante que eu desconheca.
Por isso mantive o nome "card-java" e nao apaguei os outros cards que estao no css.